### PR TITLE
Add z-index to ".site-nav" CSS

### DIFF
--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -45,6 +45,7 @@
         position: absolute;
         top: 9px;
         right: 30px;
+        z-index: 10;
         background-color: $background-color;
         border: 1px solid $grey-color-light;
         border-radius: 5px;


### PR DESCRIPTION
Fixes nav menu layering behind cards on small screens
