### PR TITLE
Fix formatting of Yelp .MD files

### DIFF
--- a/_resourcearticle/yelps-got-style-and-the-guide-to-back-it-up.md
+++ b/_resourcearticle/yelps-got-style-and-the-guide-to-back-it-up.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Yelp's got style (and the guide to back it up)
 link: http://engineeringblog.yelp.com/2014/02/yelps-got-style-and-the-guide-to-back-it-up.html
 author: Molly Finkle

--- a/_resourceexample/yelp.md
+++ b/_resourceexample/yelp.md
@@ -1,6 +1,7 @@
-﻿---
+---
 title: Yelp
 link: http://www.yelp.com/styleguide
 status: recommended
 ---
+
 Yelp's website style guide


### PR DESCRIPTION
I noticed that the Yelp example + article I added earlier weren't showing up on the website, even though my pull request was merged.

Having a look at a screenshot of the preview of the MD file in GitHub, it was pretty obvious I messed something up in the creation of the file:

![yelp-md-before](https://cloud.githubusercontent.com/assets/2629322/5072067/95f80584-6e7f-11e4-9df0-3af33871a378.png)

I must apologise, as I never actually tested the articles locally (I'm on Windows). :/ I used my IDE (PhpStorm) to create the files again, instead of Notepad which I used this morning. So I think that had something to do with it too.

Anyway, I also got Ruby installed on my PC and have the styleguides project running locally. I copied one of the existing MD files and updated it with the contents from the respective Yelp example and article and it now looks like it should:

![yelp-md-after](https://cloud.githubusercontent.com/assets/2629322/5072147/02592d48-6e80-11e4-9822-9fdd82441793.png)

And now they show up on the examples and articles pages. :)

Sorry about that!
