### PR TITLE
Fix titles not displaying on home page if image exists

### DIFF
--- a/_includes/talks.html
+++ b/_includes/talks.html
@@ -17,7 +17,7 @@
                     {% if talk.image %}<img src="/images/screenshots/{{ talk.image }}" alt="{{ talk.title }}"/>{% endif %}
                 {% endif %}
                 <span class="resource-description">
-                    {% if talk.image == null %}
+                    {% if talk.image == null or page.title == "Style Guides" %}
                         <h2 class="resource-title">{{ talk.title }}</h2>
                     {% else %}
                         <h2 class="resource-title hidden">{{ talk.title }}</h2>


### PR DESCRIPTION
Currently on the home page: http://styleguides.io talks which have an image, but are not recommended, are not displaying a title:

![home-page-before](https://cloud.githubusercontent.com/assets/2629322/5130152/f8b3eabc-70f0-11e4-8532-0f95f641f112.png)

I made a small change which seems to fix it:

![home-page-after](https://cloud.githubusercontent.com/assets/2629322/5130136/c90e5e46-70f0-11e4-8329-0f7c617f234a.png)

The talks page works as expected: an image is displayed if it exists, even if the status isn't recommended
