### PR TITLE
add scss-lint

### DIFF
--- a/_resourcetool/scss-lint.md
+++ b/_resourcetool/scss-lint.md
@@ -1,0 +1,8 @@
+---
+title: scss-lint
+link: https://github.com/causes/scss-lint
+author: causes
+language: SCSS
+---
+
+scss-lint is a tool to help keep your SCSS files clean and readable


### PR DESCRIPTION
may not agree with me on this one, but if the whole point of a styleguide is to have consistency and predictability then linters for the visual language should be in it! 

This is not DIRECTLY related to the actual construction of a styleguide, but in my experience it is absolutely crucial to have a linter if you are thinking about making your own!

Cheers!
