### PR TITLE
"Add" links and titles are now working

### DIFF
--- a/articles.html
+++ b/articles.html
@@ -2,6 +2,7 @@
 layout: page
 title: Articles
 section: articles
+type: article
 ---
 
 {% include articles.html %}

--- a/books.html
+++ b/books.html
@@ -2,6 +2,7 @@
 layout: page
 title: Books
 section: books
+type: book
 ---
 
 {% include books.html %}

--- a/examples.html
+++ b/examples.html
@@ -2,6 +2,7 @@
 layout: page
 title: Examples
 section: examples
+type: example
 ---
 
 {% include examples.html %}

--- a/index.html
+++ b/index.html
@@ -1,6 +1,7 @@
 ---
 layout: page
 section: home
+type: home
 ---
 
 {% include articles.html %}

--- a/podcasts.html
+++ b/podcasts.html
@@ -2,6 +2,7 @@
 layout: page
 title: Podcasts
 template: podcasts
+type: podcast
 ---
 
 {% include podcasts.html %}

--- a/talks.html
+++ b/talks.html
@@ -2,6 +2,7 @@
 layout: page
 title: Talks
 section: talks
+type: talk
 ---
 
 {% include talks.html %}

--- a/tools.html
+++ b/tools.html
@@ -2,6 +2,7 @@
 layout: page
 title: Tools
 section: tools
+type: tool
 ---
 
 {% include tools.html %}


### PR DESCRIPTION
I don't know if you knew about this, but a colleague wanted to add a resource today and the link was broken (it was going to `_resources` instead of `_resourcewhatever`). All the pages were missing the type attribute.

Love the project by the way! Makes me wanna dance like this:

![image](http://media.giphy.com/media/13p77tfexyLtx6/giphy.gif)
