### PR TITLE
Capitalize the "P" in WordPress

### DIFF
--- a/_resourceexample/wordpress-brand.md
+++ b/_resourceexample/wordpress-brand.md
@@ -1,5 +1,5 @@
 ---
-title: Wordpress Brand Guidelines
+title: WordPress Brand Guidelines
 link: http://wordpress.org/about/logos/
 type: Brand Guidelines
 tags: 

--- a/_resourceexample/wordpress.md
+++ b/_resourceexample/wordpress.md
@@ -1,9 +1,9 @@
 ---
-title: Wordpress Coding Standards
+title: WordPress Coding Standards
 link: https://make.wordpress.org/core/handbook/coding-standards/
 tags: 
 - code
 - frontend
 ---
 
-A baseline for contributing CSS, HTML, Javascript, and PHP to Wordpress Core
+A baseline for contributing CSS, HTML, Javascript, and PHP to WordPress Core


### PR DESCRIPTION
The "P" in WordPress should always be capitalized. 

See: https://codex.wordpress.org/Function_Reference/capital_P_dangit
