### PR TITLE
Add missing description to SDD article

### DIFF
--- a/_resourcearticle/styleguide-driven-development.md
+++ b/_resourcearticle/styleguide-driven-development.md
@@ -4,3 +4,5 @@ link: http://webuild.envato.com/blog/styleguide-driven-development
 author: Jordan Lewis
 site: Envato
 ---
+
+Styleguide Driven Development (SDD) is a practice that encourages the separation of UX, Design & Frontend from Backend concerns. This is achieved by developing the UI separately in a styleguide.


### PR DESCRIPTION
When I added my [Styleguide Driven Development](http://webuild.envato.com/blog/styleguide-driven-development/) article a while back, I forgot to include a description. This is just a tiny update to add it.
