### PR TITLE
Fix: Jekyll build problem with titles

### DIFF
--- a/_resourcearticle/atomic-contents-managing-dynamic-components.md
+++ b/_resourcearticle/atomic-contents-managing-dynamic-components.md
@@ -1,5 +1,5 @@
 ---
-title: Atomic Components: Managing Dynamic React Components using Atomic Design — Part 1
+title: 'Atomic Components: Managing Dynamic React Components using Atomic Design — Part 1'
 link: https://medium.com/@yejodido/atomic-components-managing-dynamic-react-components-using-atomic-design-part-1-5f07451f261f
 author: Joey Di Nardo
 site: Medium

--- a/_resourcearticle/keeping-your-ever-evolving-brand-consistent-the-digital-style-guide.md
+++ b/_resourcearticle/keeping-your-ever-evolving-brand-consistent-the-digital-style-guide.md
@@ -1,5 +1,5 @@
 ---
-title: Keeping your ever-evolving brand consistent: the digital style guide
+title: 'Keeping your ever-evolving brand consistent: the digital style guide'
 link: https://www.devbridge.com/articles/keeping-your-ever-evolvoing-brand-consistent-the-digital-style-guide/
 author: Mark Ludemann
 site: DevBridge


### PR DESCRIPTION
YAML parses colons, so surrounding a title that has a colon in quotes
prevents Jekyll build errors.

This fixes the issue on my end. Give this a test and see if it works for you.

This should fix two missing post titles and links:

<img width="900" alt="2015-10-30 19 11 59" src="https://cloud.githubusercontent.com/assets/885300/10860107/7409283c-7f3a-11e5-868d-d8a148efc8c6.png">
