### PR TITLE
Add Flask-Styleguide extension into Tools

### DIFF
--- a/_resourcetool/flask-styleguide.md
+++ b/_resourcetool/flask-styleguide.md
@@ -1,0 +1,8 @@
+---
+title: Flask-Styleguide
+link: http://flask-styleguide.readthedocs.org/en/latest/
+author: Vital Kudzelka
+language: Python, HTML, CSS, SCSS, Less
+---
+
+[Flask](http://flask.pocoo.org/) extension which provides an easy way to automatically generate styleguide from [KSS](http://warpspire.com/kss/) documentation format.


### PR DESCRIPTION
Extension provide an easy way to automatically generate styleguide for your Flask application from [KSS documentation](http://warpspire.com/kss/) format.
