### PR TITLE
Remove links from Flask-Styleguide content to prevent broken layout

### DIFF
--- a/_resourcetool/flask-styleguide.md
+++ b/_resourcetool/flask-styleguide.md
@@ -5,4 +5,4 @@ author: Vital Kudzelka
 language: Python, HTML, CSS, SCSS, Less
 ---
 
-[Flask](http://flask.pocoo.org/) extension which provides an easy way to automatically generate styleguide from [KSS](http://warpspire.com/kss/) documentation format.
+Flask extension which provides an easy way to automatically generate styleguide from KSS documentation format.


### PR DESCRIPTION
Looks like I missed the warning about inner links

> Do not add any links to the content because the whole thing is wrapped in a link tag, so adding another link will stop it working.

So I removed them to prevent broken layout. Sorry for inconvenience.
