### PR TITLE
Create bbc-gel-beta.md

### DIFF
--- a/_resourceexample/bbc-gel-beta.md
+++ b/_resourceexample/bbc-gel-beta.md
@@ -1,0 +1,9 @@
+---
+title: "BBC GEL - beta"
+link: "http://www.bbc.co.uk/gel/beta"
+tags:
+ - designlanguage
+ - patterns
+---
+
+Beta version of the updated BBC GEL (Global Experience Language)


### PR DESCRIPTION
This update currently sits under a `.../beta` URL but will probably replace the current BBC GEL pages in time. Will require updating at this point but useful to reference both currently.
