### PR TITLE
Update url to Fractal's site

### DIFF
--- a/_resourcetool/fractal.md
+++ b/_resourcetool/fractal.md
@@ -1,6 +1,6 @@
 ---
 title: Fractal
-link: https://github.com/frctl/fractal
+link: http://fractal.build
 language: JavaScript
 author: Mark Perkins
 image: fractal.png


### PR DESCRIPTION
Fractal 1.0 just launched and has a dedicated url now. Switched from the github repository to that's sites url.
