### PR TITLE
Enhance tag filters initial commit

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -22,19 +22,43 @@
 
     <script>
 
-    $(".tags :checkbox").click(function() {
-       $(".resource").hide();
-       $(".tags :checkbox:checked").each(function() {
-           $("." + $(this).val()).show();
-           $(".tags .show-all:checkbox").prop('checked', false);
-       });
-    });
+    $(document).ready(function() {
+      // If selections in url show them in tags and resources
+      var hash = location.hash;
+      if (hash.length) {
+        var selected_tags = hash.substr(1).split(',');
+        $('.resource').hide();
+        $('.tags :checkbox').prop('checked', false);
 
-    $(".tags .show-all:checkbox").click(function() {
-      $(".resource").show();
-      $(".tags :checkbox").each(function() {
-          $(this).prop('checked', false);
-          $(".tags .show-all:checkbox").prop('checked', true);
+        selected_tags.forEach(function(value) {
+          $('.tags :checkbox[value="' + value + '"]').prop('checked', true);
+          $('.' + value).show();
+        });
+      }
+
+      // Toggle tag state & url history
+      $('.tags :checkbox').click(function() {
+        var selected_tags = [];
+        $('.resource').hide();
+
+        if ($('.tags :checkbox:checked').length) {
+          $('.tags .show-all:checkbox').prop('checked', false);
+          $('.tags :checkbox:checked').each(function() {
+            selected_tags.push($(this).val());
+            $('.' + $(this).val()).show();
+          });
+          history.pushState(undefined, '', '#' + selected_tags.join(','));
+        } else {
+          $('.tags .show-all:checkbox').trigger('click');
+        }
+      });
+
+      // Show all resources and uncheck tags
+      $('.tags .show-all:checkbox').click(function() {
+        $('.resource').show();
+        $('.tags :checkbox').prop('checked', false);
+        $('.tags .show-all:checkbox').prop('checked', true);
+        history.pushState(undefined, '', window.location.pathname);
       });
     });
 


### PR DESCRIPTION
Hello,
This does adds some functionality to the filters in each section based on the #126 issue.

Work so far:
* Refactor JS to add selected tags to the url and keep the results on each url visit. The selected tags are being added to the url’s hash separated by comma e.g. 
http://styleguides.io/articles#code,frontend
* If all tags are unchecked the “show all” tag is being selected.
* Move code under “DOM ready” function.
* Tested in Chrome, Firefox, Safari on a Mac.
* Some code styling fixes (single quotes in favour of double, indentation).

The JS could be added to an external file to be separate from the markup (although, it’s one more request).

Cheers! 🍻