### PR TITLE
Fix tags duplications

### DIFF
--- a/_includes/tags.html
+++ b/_includes/tags.html
@@ -13,9 +13,9 @@
 {% assign tags = tags | sort %}
 {% for tag in tags %}
   {% assign tag_items = tag | split: "|" %}
-  <!-- If not equal to previous then it must be unique as sorted -->
+  {% comment %} <!-- If not equal to previous then it must be unique as sorted --> {% endcomment %}
   {% unless tag_items[0] == previous %}
-    <!-- Push to unique_tags -->
+    {% comment %} <!-- Push to unique_tags --> {% endcomment %}
     {% assign unique_tags = unique_tags | push: tag_items[1] %}
   {% endunless %}
 

--- a/_includes/tags.html
+++ b/_includes/tags.html
@@ -3,23 +3,21 @@
 {% assign tags = '' | split: ',' %}
 {% assign unique_tags = '' | split: ',' %}
 <!-- Map and flatten -->
-{% assign article_tags =  section | map: 'tags' | join: ',' | join: ',' | split: ',' %}
+{% assign article_tags =  section | map: 'tags' | join: ',' | join: ',' | upcase | split: ','   %}
 <!-- Push to tags -->
-{% for tag in article_tags '%}
-  {% capture tmp_tag %}{{ tag | downcase }}|{{ tag }}{% endcapture %}
-  {% assign tags = tags | push: tmp_tag %}
+{% for tag in article_tags %}
+  {% assign tags = tags | push: tag %}
 {% endfor %}
 <!-- Uniq -->
 {% assign tags = tags | sort %}
 {% for tag in tags %}
-  {% assign tag_items = tag | split: "|" %}
   {% comment %} <!-- If not equal to previous then it must be unique as sorted --> {% endcomment %}
-  {% unless tag_items[0] == previous %}
+  {% unless tag == previous %}
     {% comment %} <!-- Push to unique_tags --> {% endcomment %}
-    {% assign unique_tags = unique_tags | push: tag_items[1] %}
+    {% assign unique_tags = unique_tags | push: tag %}
   {% endunless %}
 
-  {% assign previous = tag_items[0] %}
+  {% assign previous = tag %}
 {% endfor %}
 <div class="tags">
   <ul class="tag">

--- a/_includes/tags.html
+++ b/_includes/tags.html
@@ -6,17 +6,20 @@
 {% assign article_tags =  section | map: 'tags' | join: ',' | join: ',' | split: ',' %}
 <!-- Push to tags -->
 {% for tag in article_tags '%}
-{% assign tags = tags | push: tag %}
+  {% capture tmp_tag %}{{ tag | downcase }}|{{ tag }}{% endcapture %}
+  {% assign tags = tags | push: tmp_tag %}
 {% endfor %}
 <!-- Uniq -->
 {% assign tags = tags | sort %}
 {% for tag in tags %}
+  {% assign tag_items = tag | split: "|" %}
   <!-- If not equal to previous then it must be unique as sorted -->
-  {% unless tag == previous %}
+  {% unless tag_items[0] == previous %}
     <!-- Push to unique_tags -->
-  {% assign unique_tags = unique_tags | push: tag %}
+    {% assign unique_tags = unique_tags | push: tag_items[1] %}
   {% endunless %}
-  {% assign previous = tag %}
+
+  {% assign previous = tag_items[0] %}
 {% endfor %}
 <div class="tags">
   <ul class="tag">


### PR DESCRIPTION
Hello!

There was a problem in the Tools section where some tags had duplicates. 
Unfortunately Liquid’s sort is case sensitive. The order was SASS,SCSS,Sass and the check with the previous tag was failing.

Liquid has a “new” filter called `sort_natural` which solves this issue, but isn’t supported in Jekyll’s liquid yet.

We could change SASS to Sass but doesn’t feel like the right way 😛

With this fix capitalisation won’t be a problem anymore.

Instead of sorting the original tags, we add a downcased version of it (e.g. html|HTML,css|Css,js,JS). Then we compare the previous tag with the first part of the tag ( e.g. css == html).

I also added `{% comment %}` tags for some HTML comments inside loops that caused 1000 blank lines and comments in some cases (e.g. Examples page).

I hope this helps 🍻