### PR TITLE
Add focus on tags

### DIFF
--- a/_sass/_tags.scss
+++ b/_sass/_tags.scss
@@ -75,4 +75,12 @@
       color: #000;
     }
   }
+  // Based on https://ghinda.net/article/mimic-native-focus-css/
+  &:focus + .tag__item__label {
+    outline: 2px auto Highlight;
+
+    @media (-webkit-min-device-pixel-ratio: 0) {
+      outline: 5px auto -webkit-focus-ring-color;
+    }
+  }
 }


### PR DESCRIPTION
Hello,

Added a focus state on tags for better keyboard navigation accessibility.

I wanted to avoid the use of JS for this so here are the drawbacks:

- This won't be consistent with the default focus styling for non webkit browsers, but it's better than nothing. (style based on https://ghinda.net/article/mimic-native-focus-css/).
- Also, when a user clicks a tag the focus state stays because it's a checkbox.

If you can think of another easier/better way to do this, please do tell ☺️

Cheers!

P.S. @maban Thanks for the invitation 🙂



