### PR TITLE
Fix Jekyll compilation errors

### DIFF
--- a/_resourceexample/firefox-photon.md
+++ b/_resourceexample/firefox-photon.md
@@ -7,5 +7,5 @@ tags:
  - patterns
  - designlanguage
  - ui
- components
+ - components
 ---

--- a/_resourcetool/design-system-starter-kit.md
+++ b/_resourcetool/design-system-starter-kit.md
@@ -1,5 +1,5 @@
 ---
-title: Creating a Design System: The Step-by-Step Guide
+title: "Creating a Design System: The Step-by-Step Guide"
 link: https://www.uxpin.com/create-design-system-guide
 language: JavaScript, CSS, HTML
 author: UXPin


### PR DESCRIPTION
Jekyll complained with two errors, both were due to a mistake in YAML syntax.