### PR TITLE
Update the url for the WordPress style-guide

### DIFF
--- a/_resourceexample/wordpress-brand.md
+++ b/_resourceexample/wordpress-brand.md
@@ -1,6 +1,6 @@
 ---
 title: WordPress Brand Guidelines
-link: http://wordpress.org/about/logos/
+link: https://make.wordpress.org/design/handbook/design-guide/
 image: wordpress.jpg
 type: Brand Guidelines
 tags:


### PR DESCRIPTION
The url was outdated. The latest WordPress brand resources live in the Design Handbook.