### PR TITLE
Add .com

### DIFF
--- a/_resourceexample/wordpress-design-handbook.md
+++ b/_resourceexample/wordpress-design-handbook.md
@@ -1,5 +1,5 @@
 ---
-title: WordPress Design Handbook
+title: WordPress.com Design Handbook
 link: https://wordpress.com/design-handbook/
 image: wordpress-design-handbook.png
 tags:


### PR DESCRIPTION
This Design Handbook is for WordPress.com, NOT the open source WordPress.