### PR TITLE
Fix 404 for Codepen with Wayback Machine

### DIFF
--- a/_resourceexample/codepen.md
+++ b/_resourceexample/codepen.md
@@ -1,6 +1,6 @@
 ---
 title: Codepen's design patterns
-link: http://codepen.io/guide/
+link: https://web.archive.org/web/20170523012226/http://codepen.io/guide/
 image: http_codepen.io_guide_.jpg
 recommended: true
 status: recommended
@@ -8,4 +8,4 @@ tags:
  - patterns
 ---
 
-The design patterns used in Codepen
+Codepen's old design patterns, now deprecated for fractal.build.


### PR DESCRIPTION
More recently Codepen have deprecated this for Fractal [1], but at least the link isn't broken now.

[1] https://web.archive.org/web/20181207200041/https://codepen.io/guide