### PR TITLE
Fix Carbon link

### DIFF
--- a/_resourceexample/carbon.md
+++ b/_resourceexample/carbon.md
@@ -1,6 +1,6 @@
 ---
 title: Carbon Design System
-link: http://carbondesignsystem.com/
+link: https://www.carbondesignsystem.com/
 author: IBM
 status: recommended
 image: carbon-image.png


### PR DESCRIPTION
The current link displays a "Site not found" error.