### PR TITLE
Fix broken link to poor-mans-styleguide

### DIFF
--- a/_resourcetool/poor-mans-styleguide.md
+++ b/_resourcetool/poor-mans-styleguide.md
@@ -1,6 +1,6 @@
 ---
 title: Poor Man's Styleguide
-link: http://www.poormansstyleguide.com/
+link: https://www.bryanbraun.com/poor-mans-styleguide
 author: Bryan Braun
 language: HTML, Markdown
 ---


### PR DESCRIPTION
Poor Man's Styleguide was recently moved from http://poormansstyleguide.com to https://www.bryanbraun.com/poor-mans-styleguide.

This PR should fix the broken link. 👍